### PR TITLE
Fix example spec test ID to valid 5-char format

### DIFF
--- a/checksum-root/example.checksum.spec.ts
+++ b/checksum-root/example.checksum.spec.ts
@@ -7,7 +7,7 @@ test.describe("Example test", () => {
   });
 
   test(
-    defineChecksumTest("Navigate to home page", "TEST_ID"),
+    defineChecksumTest("Navigate to home page", "TSTID"),
     async ({ page }) => {
       await page.goto("/");
     }


### PR DESCRIPTION
## Summary
- Replace `"TEST_ID"` (7 characters) with `"TSTID"` (5 characters) in the example spec template
- The system expects 5-character alphanumeric IDs; this was broken in v1.2.0 when the original valid ID was replaced with a placeholder

## Test plan
- [x] Verified `"TSTID"` is exactly 5 alphanumeric characters
- [x] Verified file parses as valid TypeScript
- [x] Tested locally with `npm pack` + `npx checksumai init` — generated file contains the correct ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)